### PR TITLE
Fixed error under vite5: globEager is not a function

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,7 @@ app.use(ArcoVue, {})
 .use(globalComponents)
 
 // 注册ma-icon图标
-const modules = import.meta.globEager('./assets/ma-icons/*.vue')
+const modules = import.meta.glob('./assets/ma-icons/*.vue', { eager: true })
 for (const path in modules) {
   const name = path.match(/([A-Za-z0-9_-]+)/g)[2]
   const componentName = `MaIcon${name}`


### PR DESCRIPTION
vite5中import.meta.globEager已经被废弃