### PR TITLE
The data retrieved from the backend can be adjusted with the afterRequest method

### DIFF
--- a/src/components/ma-crud/index.vue
+++ b/src/components/ma-crud/index.vue
@@ -482,7 +482,7 @@ const requestHandle = async () => {
   } else {
     console.error(`ma-crud error：crud.api not is Function.`)
   }
-  isFunction(options.value.afterRequest) && options.value.afterRequest(tableData.value)
+  isFunction(options.value.afterRequest) && (tableData.value = options.value.afterRequest(tableData.value))
   loading.value = false
 }
 


### PR DESCRIPTION
目前组件无其他公开方法可以修改从后端获取到的值。
afterRequest方法应该承接该作用，但目前只是获取了该数据，未能做其他处理。
现重新赋值后，从后端获取到的数据，如 `1,2,3`可以切分为[1,2,3]，就能对应上单选框的值了。