### PR TITLE
fix: Fix the issue of listening for submission events in the 'ma-form…

### DIFF
--- a/src/views/setting/config/index.vue
+++ b/src/views/setting/config/index.vue
@@ -210,6 +210,7 @@
     const response = await config.updateByKeys(data)
     if (response.success) {
       Message.success(response.message)
+      getConfigGroupList()
     }
   }
 

--- a/src/views/setting/config/index.vue
+++ b/src/views/setting/config/index.vue
@@ -42,7 +42,7 @@
           <ma-form
             v-model="formArray[item.id]"
             :columns="optionsArray[item.id]"
-            @onSubmit="submit"
+            @submit="submit"
             class="mt-3"
             ref="maFormRef"
           />
@@ -130,7 +130,7 @@
     let form = {}
     optionsArray.value[id] = response.data.map(item => {
       let option = {
-        title: item.name, dataIndex: item.key, formType: item.input_type, 
+        title: item.name, dataIndex: item.key, formType: item.input_type,
         dict: {}, labelWidth: '120px', extra: item.remark, tooltip: item.key,
       }
       const allowDictType = ['select', 'radio', 'checkbox']


### PR DESCRIPTION
![image](https://github.com/mineadmin/MineAdmin-Vue/assets/37197772/ebeb57a1-6059-4372-bca6-011b863b5c44)
![image](https://github.com/mineadmin/MineAdmin-Vue/assets/37197772/6a819e3b-7a53-45f1-b0af-c325b503871b)
![image](https://github.com/mineadmin/MineAdmin-Vue/assets/37197772/2b685b34-d667-4252-8fe3-6a745f4270f2)
![image](https://github.com/mineadmin/MineAdmin-Vue/assets/37197772/aa2b2973-60a7-4529-b4c6-fe6c4a40d6d3)

When calling ma form, the caller is listening for the onSubmit event, but the submit event is triggered within the ma form component, which prevents the module from submitting properly

当调用ma-form时，调用方监听的是onSubmit事件，但是ma-form组件内触发的是submit事件，导致该模块无法正常提交