### PR TITLE
fix:修复cascader搜索时不起效的问题

### DIFF
--- a/src/components/ma-form/js/networkRequest.js
+++ b/src/components/ma-form/js/networkRequest.js
@@ -75,6 +75,10 @@ export const handlerDictProps = (item, tmpArr) => {
       else value = tmp
       tran[value] = label
       colors[value] = item.dict.tagColors && item.dict.tagColors[value] || undefined
+      if (item.formType === 'cascader' && dicItem.children) {
+        let children = dicItem.children;
+        return { label, value, disabled, indeterminate, children }
+      }
       return { label, value, disabled, indeterminate }
     })
   } else {


### PR DESCRIPTION
当搜索设置cascader时，没有设置children导致联级出现展示问题，只能显示一级