### PR TITLE
Fix. Fixed the command map loop true being overwritten under multiple roles.

### DIFF
--- a/src/directives/role/index.js
+++ b/src/directives/role/index.js
@@ -7,7 +7,9 @@ const checkRole = (el, binding) => {
     if (value.length > 0) {
       let isHas = false
       value.map(item => {
-        isHas = role(item)
+        if(!isHas) {
+          isHas = role(item)
+        }
       })
 
       if (!isHas && el.parentNode) {


### PR DESCRIPTION
修复指令在多角色下map循环true被覆盖