### PR TITLE
perf(ma-crud): 优化setSearchHidden 防止页面抖动 优化fixed布局下的元素高度

### DIFF
--- a/src/components/ma-crud/index.vue
+++ b/src/components/ma-crud/index.vue
@@ -401,7 +401,11 @@ watch(
   vl => options.value.api = vl
 )
 
-watch( () => openPagination.value, () => options.value.pageLayout === 'fixed' && settingFixedPage() )
+watch([
+  () => openPagination.value,
+  () => total.value
+], () => options.value.pageLayout === 'fixed' && settingFixedPage() )
+
 
 watch(
     () => formStore.crudList[options.value.id],
@@ -574,7 +578,7 @@ const toggleSearch = async () => {
 
 const settingFixedPage = () => {
   const workAreaHeight = document.querySelector('.work-area').offsetHeight
-  const tableHeight = workAreaHeight - headerHeight.value - (openPagination.value ? 152 : 108)
+  const tableHeight = workAreaHeight - headerHeight.value - (openPagination.value ? 160 : 116) + (total.value === 0 && !loading.value ?  44: 0)
   crudContentRef.value.style.height = tableHeight + 'px'
 }
 
@@ -816,15 +820,15 @@ onMounted(async() => {
   if (! options.value.expandSearch && crudSearchRef.value) {
     crudSearchRef.value.setSearchHidden()
   }
-
+  if (options.value.pageLayout === 'fixed') {
+    await nextTick(() => {
+      window.addEventListener('resize', resizeHandler, false);
+      headerHeight.value = crudHeaderRef.value.offsetHeight
+      settingFixedPage()
+    })
+  }
   if (typeof options.value.autoRequest == 'undefined' || options.value.autoRequest) {
     await requestData()
-  }
-
-  if (options.value.pageLayout === 'fixed') {
-    window.addEventListener('resize', resizeHandler, false);
-    headerHeight.value = crudHeaderRef.value.offsetHeight
-    settingFixedPage()
   }
 })
 

--- a/src/components/ma-crud/index.vue
+++ b/src/components/ma-crud/index.vue
@@ -813,12 +813,12 @@ const changeColumn = async () => {
 }
 
 onMounted(async() => {
-  if (typeof options.value.autoRequest == 'undefined' || options.value.autoRequest) {
-    await requestData()
-  }
-
   if (! options.value.expandSearch && crudSearchRef.value) {
     crudSearchRef.value.setSearchHidden()
+  }
+
+  if (typeof options.value.autoRequest == 'undefined' || options.value.autoRequest) {
+    await requestData()
   }
 
   if (options.value.pageLayout === 'fixed') {


### PR DESCRIPTION
调整setSearchHidden在onMounted里的执行时机,使得在请求开始前先执行,防止页面因请求比较慢导致的先展示再请求再修改搜索面板隐藏导致的页面抖动问题