### PR TITLE
fix: 修复菜单编辑选择图标未能清除问题

### DIFF
--- a/src/components/ma-icon/index.vue
+++ b/src/components/ma-icon/index.vue
@@ -48,22 +48,31 @@
 </template>
 
 <script setup>
-  import { reactive, ref, onMounted } from 'vue'
+  import { reactive, ref, computed } from 'vue'
   import * as arcoIcons from '@arco-design/web-vue/es/icon'
 
   const mineadminIcons = reactive([])
   const arcodesignIcons = reactive([])
   const visible = ref(false)
-  const currentIcon = ref()
 
   const props = defineProps({
     modelValue: { type: String },
     preview: { type: Boolean, default: true },
   })
-  
+
   const emit = defineEmits(['update:modelValue'])
 
-  onMounted( () => currentIcon.value = props.modelValue )
+  const currentIcon = computed({
+    get() {
+      return props.modelValue;
+    },
+    set(value) {
+      // html标签名不能以数字开头
+      if ((/^[^\d].*/.test(value) && value) || !value) {
+        emit('update:modelValue', value);
+      }
+    }
+  });
 
   for (let icon in arcoIcons) {
     arcodesignIcons.push(icon)
@@ -79,7 +88,6 @@
 
   const selectIcon = (icon, className) => {
     currentIcon.value = icon
-    emit('update:modelValue', currentIcon.value)
     visible.value = false
   }
 


### PR DESCRIPTION
<img width="654" alt="image" src="https://github.com/mineadmin/MineAdmin-Vue/assets/63382474/d874c06b-82bc-4765-b0dc-48b47d3229df">

1，修复清除图标时 未能正常赋值 也就是清空了图标 提交还是上次的图标 
2，修复如果输入文本第一个为数字时 会报错类似 Failed to execute 'createElement' on 'Document': The tag name provided ('1IconHome') is not a valid name. 原因是 html标签名不能以数字开头
<img width="1118" alt="image" src="https://github.com/mineadmin/MineAdmin-Vue/assets/63382474/b2a8e23c-8eff-49a0-97a3-d0968b0cb54c">
