### PR TITLE
修复MaCrud组件beforeOpenEdit函数BUG

### DIFF
--- a/src/components/ma-crud/components/column.vue
+++ b/src/components/ma-crud/components/column.vue
@@ -269,8 +269,9 @@ const seeAction = record => {
 }
 
 const editAction = record => {
-  if (isFunction(options.beforeOpenEdit) && ! options.beforeOpenEdit(record)) {
-    return false
+  if (isFunction(options.beforeOpenEdit)) {
+    const isOpen = await options.beforeOpenEdit(record)
+    if (!isOpen) return false;
   }
   if (options.edit.action && isFunction(options.edit.action)) {
     options.edit.action(record)


### PR DESCRIPTION
执行顺序问题：
当我在beforeOpenEdit方法中使用async/await 拉取数据并刷新edit数据时，不生效的问题。

beforeOpenEdit BUG复现代码示例：

const beforeOpenEdit = async (data) => {
  try {
    const info = await xxxapi.info(data.id);
    data.introduce = info.data.introduce
  } catch (e) {
    return false;
  }
  return true;
}