### PR TITLE
fix(ma-crud, ma-form): 修复多选 select 反向赋值时非对象类型导致的错误

### DIFF
--- a/src/components/ma-crud/components/searchFormItem/form-select.vue
+++ b/src/components/ma-crud/components/searchFormItem/form-select.vue
@@ -167,6 +167,7 @@ const handlerFallback = (key) => {
 watch( () => get(searchForm.value, props.component.dataIndex), vl => value.value = vl )
 watch( () => value.value, v => {
   if (props.component.multiple) {
+    if (!isObject(v)) v = []
     v.forEach(k => {
       if ( !optionMap.value[k] ) {
         optionMap.value[k] = dicts.value[dictIndex].find(i => i.value === k)

--- a/src/components/ma-form/formItem/form-select.vue
+++ b/src/components/ma-form/formItem/form-select.vue
@@ -161,6 +161,7 @@ const keyword = ref('')
 watch( () => get(formModel.value, index), vl => value.value = vl )
 watch( () => value.value, v => {
   if (props.component.multiple) {
+    if (!isObject(v)) v = []
     v.forEach(k => {
       if ( !optionMap.value[k] ) {
         optionMap.value[k] = dictList.value[dictIndex].find(i => i.value === k)


### PR DESCRIPTION
- 在 ma-crud 和 ma-form 组件中，增加了对多选 select 值类型的判断
- 当值不是对象时，将其转换为数组，避免遍历操作时的错误 
- Close #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of multiple selections in the form select component.
	- Added a popover to display selected items and a search input for improved user interaction.
	- Integrated pagination in the dropdown for easier navigation through options.

- **Bug Fixes**
	- Improved initialization of value state to prevent errors with undefined selections.
	- Refined logic for managing selected options to ensure robust performance.

- **Improvements**
	- Adjusted computed properties for better responsiveness to selection changes and keyword filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->