### PR TITLE
fix(ma-editor): 修复同一时刻渲染多富文本无效

### DIFF
--- a/src/components/ma-editor/index.vue
+++ b/src/components/ma-editor/index.vue
@@ -68,7 +68,7 @@ const appStore = useAppStore()
 const props = defineProps({
   modelValue: {type: String},
   height: {type: Number, default: 400},
-  id: {type: String, default: () => 'tinymce' + new Date().getTime().toString()},
+  id: {type: String, default: () => tool.uuid()},
   plugins: {
     type: [String, Array],
     default:
@@ -132,7 +132,7 @@ const getStoreMode = (mode) => {
   return uploadConfig.storageMode[mode.toString()]
 }
 
-const editorKey = ref(new Date().getTime())
+const editorKey = props.id
 
 watch(
     () => list.value,

--- a/src/utils/tool.js
+++ b/src/utils/tool.js
@@ -359,4 +359,16 @@ tool.arrSum = (arr) => {
   return sum
 }
 
+tool.uuid = () => {
+  const randomBytes = CryptoJS.lib.WordArray.random(16);
+  const randomHex = randomBytes.toString(CryptoJS.enc.Hex);
+  return [
+    randomHex.substr(0, 8),
+    randomHex.substr(8, 4),
+    randomHex.substr(12, 4),
+    randomHex.substr(16, 4),
+    randomHex.substr(20, 12)
+  ].join('-');
+}
+
 export default tool


### PR DESCRIPTION
fix(ma-editor): 修复同一时刻渲染多富文本无效
thx: @csdjl88, @Immask-rgb
issue: #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced editor component with unique identifier generation using UUIDs.
	- Introduced a new method for generating UUIDs in the utility tool.

- **Bug Fixes**
	- Improved consistency of the editor key with the provided props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->